### PR TITLE
Add specialized slave for Java 11 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,13 @@ buildConfig([
     'classic': {
       build('classic')
     },
+    // TODO: This is only a temporary solution to get quick Java 11 support.
+    // We want to either have Java 8 and Java 11 in the same classic slave,
+    // or make a improved Jenkinsfile to support our flows.
+    // See https://github.com/capralifecycle/buildtools-example-java-2
+    'classic-java-11': {
+      build('classic-java-11')
+    },
   )
 }
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ We build to different slaves:
 
 * *Classic slave*: Thick slave supporting classic freestyle jobs that do not
   use Docker to provide tooling. Contains JDK, node and more tooling.
+
+* *Classic slave for Java 11*: Thick slave supporting classic freestyle jobs
+  for Java 11. Contains JDK, node and more tooling. This is considered only
+  temporary until either the two classic slaves are merged or we have switch
+  to using the modern slaves/builds.

--- a/classic-java-11/Dockerfile
+++ b/classic-java-11/Dockerfile
@@ -1,0 +1,87 @@
+# Currenly no Alpine version of OpenJDK through "official" channels
+# (See https://github.com/docker-library/openjdk/issues/211)
+FROM openjdk:11-jdk-slim
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y \
+        curl \
+        git \
+        gosu \
+        openssh-client \
+        python-pip \
+        python-setuptools \
+    ; \
+    pip install awscli; \
+    rm -rf /var/lib/apt/lists/*
+
+# install Docker client
+# reference: https://github.com/docker-library/docker/blob/cf3d3343f291146f9b79ccafa725a9bb28257ea0/18.03/Dockerfile
+ENV DOCKER_CHANNEL stable
+ENV DOCKER_VERSION 18.03.1-ce
+
+RUN set -eux; \
+    curl -fSL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" -o docker.tgz; \
+    # TODO: not currently supported, see reference
+    #echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c -; \
+    tar \
+        --extract \
+        --file docker.tgz \
+        --strip-components 1 \
+        --directory /usr/local/bin/; \
+    rm docker.tgz; \
+    \
+    # install docker compose
+    pip install docker-compose
+
+# install Jenkins slave
+# inspiration: https://github.com/carlossg/jenkins-swarm-slave-docker/blob/master/Dockerfile
+# see https://wiki.jenkins-ci.org/display/JENKINS/Swarm+Plugin
+ENV JENKINS_SWARM_VERSION 3.12
+
+RUN set -eux; \
+    groupadd jenkins; \
+    useradd -m -g jenkins jenkins; \
+    curl --create-dirs -sSLo \
+        /usr/share/jenkins/swarm-client-$JENKINS_SWARM_VERSION.jar \
+        https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$JENKINS_SWARM_VERSION/swarm-client-$JENKINS_SWARM_VERSION.jar; \
+    chmod 755 /usr/share/jenkins
+
+# Setup below is additional tools used due to builds not building in Docker
+# requiring these tools to be installed in the slave itself.
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install --no-install-recommends -y \
+        btrfs-progs \
+        fontconfig \
+        gettext \
+        groff \
+        iptables \
+        jq \
+        less \
+        make \
+        maven \
+        npm \
+        supervisor \
+        ttf-dejavu \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    npm install -g yarn; \
+
+    # AWS stuff
+    curl -fSL "https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest" -o /usr/local/bin/ecs-cli; \
+    chmod +x /usr/local/bin/ecs-cli; \
+    curl -fSL https://raw.githubusercontent.com/silinternational/ecs-deploy/develop/ecs-deploy -o /usr/local/bin/ecs-deploy; \
+    chmod +x /usr/local/bin/ecs-deploy; \
+
+    # Dont check host keys when connecting with ssh (Git) from the docker container
+    sed -i 's/#   StrictHostKeyChecking .*/    StrictHostKeyChecking no/' /etc/ssh/ssh_config
+
+# TODO: Unsure if this should remain enabled in JVM 11
+# ENV JAVA_TOOL_OPTIONS "-Dsun.zip.disableMemoryMapping=true"
+
+VOLUME ["/home/jenkins/"]
+
+ADD container/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 # inspired by https://github.com/carlossg/jenkins-swarm-slave-docker/blob/master/jenkins-slave.sh
+set -eu
 
 # Add jenkins user to group owning Docker socket
 if [ -e /var/run/docker.sock ]; then
     gid=$(stat -c %g /var/run/docker.sock)
-    addgroup -g $gid docker 2>/dev/null || :
-    adduser jenkins docker || :
+
+    if [ -e /etc/alpine-release ]; then
+        addgroup -g $gid docker 2>/dev/null || :
+        adduser jenkins docker || :
+    else
+        groupadd -g $gid docker 2>/dev/null || :
+        usermod -aG docker jenkins || :
+    fi
 fi
 
 # if `docker run` first argument start with `-` the user is passing jenkins swarm launcher arguments
@@ -21,7 +28,7 @@ fi
 if [ $launcher -eq 1 ]; then
     jar=$(ls -1 /usr/share/jenkins/swarm-client-*.jar | tail -n 1)
 
-    gosu jenkins java $JAVA_OPTS -jar $jar -fsroot "/home/jenkins" "$@"
+    gosu jenkins java ${JAVA_OPTS:-} -jar $jar -fsroot "/home/jenkins" "$@"
 else
     gosu jenkins "$@"
 fi

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 # Build and test similar to in CI
 set -eux
 
-for model in modern classic; do
+for model in modern classic classic-java-11; do
   echo "Testing $model"
 
   docker build -t jenkins-slave-$model -f ./$model/Dockerfile .


### PR DESCRIPTION
This is just a temporary solution to get quick Java 11 support.
See inline comment for details.

The Docker setup is based on the other classic slave setup, but ported
to Debian instead of Alpine.